### PR TITLE
Cleansed certificate strings for dump protection

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Summary of changes
 
+## Changes for version 2.0.2 (15 Feb 2022)
+
+### Bug Fixes
+
+- Cleansed certificate strings for dump protection
+
+
 ## Changes for version 2.0.1 (8 Feb 2022)
 
 ### Bug Fixes

--- a/src/HttpLibWebServerAdapter/SecuredServer.cpp
+++ b/src/HttpLibWebServerAdapter/SecuredServer.cpp
@@ -33,6 +33,10 @@ namespace systelab { namespace web_server { namespace httplib {
 		{
 			httpLibServer.reset(new ::httplib::SSLServer(serverCertificate, serverPrivateKey, serverDHParam, "", tlsSupportMask));
 		}
+
+		std::memset(&serverCertificate[0], '0', strlen(&serverCertificate[0]));
+		std::memset(&serverPrivateKey[0], '0', strlen(&serverPrivateKey[0]));
+		std::memset(&serverDHParam[0], '0', strlen(&serverDHParam[0]));
  
 		configureRoutes(*httpLibServer);
 		httpLibServer->set_gzip_compression_enabled(m_configuration->isGZIPCompressionEnabled());


### PR DESCRIPTION
Temporary strings containing certificate keys are cleansed before destroyed to increase dump protection.